### PR TITLE
fix: fix how pending is calculated

### DIFF
--- a/src/app/api/getStats.ts
+++ b/src/app/api/getStats.ts
@@ -10,7 +10,7 @@ export interface StatsData {
   active_delegations: number;
   total_delegations: number;
   total_stakers: number;
-  unconfirmed_active_tvl: number;
+  unconfirmed_tvl: number;
 }
 
 export const getStats = async (): Promise<Stats> => {

--- a/src/app/components/Stats/Stats.tsx
+++ b/src/app/components/Stats/Stats.tsx
@@ -44,10 +44,10 @@ export const Stats: React.FC<StatsProps> = ({
       },
       {
         title: "Pending Stake",
-        value: data?.unconfirmed_active_tvl
+        value: data?.unconfirmed_tvl
           ? formatter.format(
-              +(data.unconfirmed_active_tvl / 1e8).toFixed(6) as number,
-            )
+            +(data.unconfirmed_tvl - data.active_tvl / 1e8).toFixed(6) as number,
+          )
           : 0,
         icon: pendingStake,
       },


### PR DESCRIPTION
- changed API field name from `unconfirmed_active_tvl` to `unconfirmed_tvl`
- fix how pending delegation is calculated as the unconfirmed tvl is the sum of both confirmed and unconfirmed.