### PR TITLE
add new message for current block height vs activation block height

### DIFF
--- a/src/app/components/Delegations/Delegations.tsx
+++ b/src/app/components/Delegations/Delegations.tsx
@@ -23,7 +23,10 @@ import { toLocalStorageIntermediateDelegation } from "@/utils/local_storage/toLo
 import { getIntermediateDelegationsLocalStorageKey } from "@/utils/local_storage/getIntermediateDelegationsLocalStorageKey";
 import { getCurrentGlobalParamsVersion } from "@/utils/globalParams";
 import { QueryMeta } from "@/app/types/api";
-import { LoadingTableList, LoadingView } from "@/app/components/Loading/Loading";
+import {
+  LoadingTableList,
+  LoadingView,
+} from "@/app/components/Loading/Loading";
 import {
   UnbondWithdrawModal,
   MODE,

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -69,11 +69,14 @@ export const Staking: React.FC<StakingProps> = ({
     useState<FinalityProviderInterface>();
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
   const [currentBlockHeight, setCurrentBlockHeight] = useState(0);
+  const { showError } = useError();
   const pollingInterval = 60000; // 60 seconds fetch interval
 
   const stakingParams = paramWithContext?.currentVersion;
   const isUpgrading = paramWithContext?.isApprochingNextVersion;
-  const { showError } = useError();
+  const isBlockHeightUnderActivation =
+    !stakingParams || currentBlockHeight < stakingParams.activationHeight;
+  
 
   const handleResetState = () => {
     setFinalityProvider(undefined);
@@ -243,7 +246,7 @@ export const Staking: React.FC<StakingProps> = ({
       );
     }
     // 6. Current block height has not reached activation block height
-    else if (currentBlockHeight < stakingParams.activationHeight) {
+    else if (isBlockHeightUnderActivation) {
       return (
         <Message
           title="Staking has not yet started"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,10 +64,14 @@ const Home: React.FC<HomeProps> = () => {
         getGlobalParams(),
       ]);
       try {
-        return await getCurrentGlobalParamsVersion(height + 1, versions);
+        return {
+          currentHeight: height,
+          ...getCurrentGlobalParamsVersion(height + 1, versions),
+        };
       } catch (error) {
         // No global params version found, it means the staking is not yet enabled
         return {
+          currentHeight: height,
           currentVersion: undefined,
           isApprochingNextVersion: false,
         };
@@ -109,10 +113,10 @@ const Home: React.FC<HomeProps> = () => {
         { finalityProviders: [], pagination: { next_key: "" } },
       );
       return flattenedData;
-  },
+    },
     retry: (failureCount, error) => {
       return !isErrorOpen && failureCount <= 3;
-    }
+    },
   });
 
   const {
@@ -145,10 +149,10 @@ const Home: React.FC<HomeProps> = () => {
       );
 
       return flattenedData;
-  },
+    },
     retry: (failureCount, error) => {
       return !isErrorOpen && failureCount <= 3;
-    }
+    },
   });
 
   const {


### PR DESCRIPTION
![CleanShot 2024-05-21 at 02 19 30](https://github.com/babylonchain/simple-staking/assets/168515712/b00f76f3-a2bb-4927-b613-3602d1d23d4d)

note: the block number in the above is using the correct param, since its testnet and the block has already been reached, Im just displaying it to show the format as example.
