### PR TITLE
feature: Wallet select additions

### DIFF
--- a/src/app/components/Modals/ConnectModal.tsx
+++ b/src/app/components/Modals/ConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Modal } from "react-responsive-modal";
 import { IoMdClose } from "react-icons/io";
 import { PiWalletBold } from "react-icons/pi";
@@ -21,14 +21,28 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   onConnect,
   connectDisabled,
 }) => {
+  const modalRef = useRef(null);
+  const [accepted, setAccepted] = useState(false);
+  const [selectedWallet, setSelectedWallet] = useState<string>("");
+  const [mounted, setMounted] = useState(false);
+
+  // useEffect only runs on the client, so now we can safely show the UI
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div className="flex h-[40px] w-[68px] items-center justify-center gap-1 rounded-full bg-base-100 p-2">
+        <span className="loading loading-spinner loading-xs text-primary" />
+      </div>
+    );
+  }
+
   // This constant is used to identify the browser wallet
   // And whether or not it should be injected
   const BROWSER = "btcwallet";
   const isInjectable = !!window[BROWSER];
-
-  const modalRef = useRef(null);
-  const [accepted, setAccepted] = useState(false);
-  const [selectedWallet, setSelectedWallet] = useState<string>("");
 
   const handleConnect = async () => {
     if (selectedWallet) {

--- a/src/app/components/Modals/ConnectModal.tsx
+++ b/src/app/components/Modals/ConnectModal.tsx
@@ -44,7 +44,10 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
     if (selectedWallet) {
       let walletInstance: WalletProvider;
 
-      if (isInjectable && selectedWallet === BROWSER) {
+      if (selectedWallet === BROWSER) {
+        if (!isInjectable) {
+          throw new Error("Browser selected without an injectable interface");
+        }
         // we are using the browser wallet
         walletInstance = window[BROWSER];
       } else {

--- a/src/app/components/Modals/ConnectModal.tsx
+++ b/src/app/components/Modals/ConnectModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from "react-responsive-modal";
 import { IoMdClose } from "react-icons/io";
 import { PiWalletBold } from "react-icons/pi";
 import Image from "next/image";
+import { FaWallet } from "react-icons/fa";
 
 import { walletList } from "@/utils/wallet/list";
 import { WalletProvider } from "@/utils/wallet/wallet_provider";
@@ -20,19 +21,33 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   onConnect,
   connectDisabled,
 }) => {
+  // This constant is used to identify the browser wallet
+  // And whether or not it should be injected
+  const BROWSER = "btcwallet";
+  const isInjectable = !!window[BROWSER];
+
   const modalRef = useRef(null);
   const [accepted, setAccepted] = useState(false);
   const [selectedWallet, setSelectedWallet] = useState<string>("");
 
   const handleConnect = async () => {
     if (selectedWallet) {
-      const walletProvider = walletList.find(
-        (w) => w.name === selectedWallet,
-      )?.wallet;
-      if (!walletProvider) {
-        throw new Error("Wallet provider not found");
+      let walletInstance: WalletProvider;
+
+      if (isInjectable && selectedWallet === BROWSER) {
+        // we are using the browser wallet
+        walletInstance = window[BROWSER];
+      } else {
+        // we are using a custom wallet
+        const walletProvider = walletList.find(
+          (w) => w.name === selectedWallet,
+        )?.wallet;
+        if (!walletProvider) {
+          throw new Error("Wallet provider not found");
+        }
+        walletInstance = new walletProvider();
       }
-      const walletInstance = new walletProvider();
+
       onConnect(walletInstance);
     }
   };
@@ -83,24 +98,43 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
         </div>
         <div className="my-4 flex flex-col gap-4">
           <h3 className="text-center font-semibold">Choose wallet</h3>
-          <div className="grid grid-cols-2 gap-4">
-            {walletList.map((wallet) => (
-              <div
-                key={wallet.name}
-                className={`flex cursor-pointer items-center gap-2 rounded-xl border-2 bg-base-100 p-2 transition-all hover:text-primary ${selectedWallet === wallet.name ? "border-primary" : "border-base-100"}`}
-                onClick={() => setSelectedWallet(wallet.name)}
+          <div className="grid max-h-[20rem] grid-cols-1 gap-4 overflow-y-auto">
+            {walletList.map((wallet) => {
+              const walletAvailable = !!window[wallet.provider as any];
+              return (
+                <a
+                  key={wallet.name}
+                  className={`flex cursor-pointer items-center gap-2 rounded-xl border-2 bg-base-100 p-2 transition-all hover:text-primary ${selectedWallet === wallet.name ? "border-primary" : "border-base-100"} ${!walletAvailable ? "opacity-50" : ""}`}
+                  onClick={() =>
+                    walletAvailable && setSelectedWallet(wallet.name)
+                  }
+                  href={!walletAvailable ? wallet.linkToDocs : undefined}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full border bg-white p-2">
+                    <Image
+                      src={wallet.icon}
+                      alt={wallet.name}
+                      width={26}
+                      height={26}
+                    />
+                  </div>
+                  <p>{wallet.name}</p>
+                </a>
+              );
+            })}
+            {isInjectable && (
+              <button
+                className={`flex cursor-pointer items-center gap-2 rounded-xl border-2 bg-base-100 p-2 transition-all hover:text-primary ${selectedWallet === BROWSER ? "border-primary" : "border-base-100"}`}
+                onClick={() => setSelectedWallet(BROWSER)}
               >
-                <div className="flex h-14 w-14 items-center justify-center rounded-full border bg-white p-2">
-                  <Image
-                    src={wallet.icon}
-                    alt={wallet.name}
-                    width={32}
-                    height={32}
-                  />
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border bg-white p-2 text-black">
+                  <FaWallet size={26} />
                 </div>
-                <p>{wallet.name}</p>
-              </div>
-            ))}
+                <p>Browser</p>
+              </button>
+            )}
           </div>
         </div>
         <button

--- a/src/app/components/Modals/ConnectModal.tsx
+++ b/src/app/components/Modals/ConnectModal.tsx
@@ -32,11 +32,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   }, []);
 
   if (!mounted) {
-    return (
-      <div className="flex h-[40px] w-[68px] items-center justify-center gap-1 rounded-full bg-base-100 p-2">
-        <span className="loading loading-spinner loading-xs text-primary" />
-      </div>
-    );
+    return null;
   }
 
   // This constant is used to identify the browser wallet

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -236,13 +236,7 @@ const Home: React.FC<HomeProps> = () => {
   const [connectModalOpen, setConnectModalOpen] = useState(false);
 
   const handleConnectModal = () => {
-    // check if there's a window.btcwallet and use the default wallet provider
-    if (window.btcwallet) {
-      handleConnectBTC(window.btcwallet);
-    } else {
-      // show a wallet selection modal
-      setConnectModalOpen(true);
-    }
+    setConnectModalOpen(true);
   };
 
   const handleDisconnectBTC = () => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,9 +4,9 @@ export {};
 
 declare global {
   interface Window {
+    btcwallet: WalletProvider;
     btc: any;
     keplr: any;
     okxwallet: any;
-    btcwallet: WalletProvider;
   }
 }

--- a/src/utils/wallet/list.ts
+++ b/src/utils/wallet/list.ts
@@ -1,4 +1,4 @@
-import { OKXWallet } from "./providers/okx_wallet";
+import { OKXWallet, okxProvider } from "./providers/okx_wallet";
 import okxIcon from "./icons/okx.svg";
 
 export const walletList = [
@@ -6,5 +6,7 @@ export const walletList = [
     name: "OKX",
     icon: okxIcon,
     wallet: OKXWallet,
+    provider: okxProvider,
+    linkToDocs: "https://www.okx.com/web3",
   },
 ];

--- a/src/utils/wallet/providers/okx_wallet.ts
+++ b/src/utils/wallet/providers/okx_wallet.ts
@@ -1,4 +1,10 @@
-import { WalletProvider, Network, Fees, UTXO } from "../wallet_provider";
+import {
+  WalletProvider,
+  Network,
+  Fees,
+  UTXO,
+  WalletInfo,
+} from "../wallet_provider";
 import {
   getAddressBalance,
   getTipHeight,
@@ -7,13 +13,11 @@ import {
   pushTx,
 } from "../../mempool_api";
 
-type OKXWalletInfo = {
-  publicKeyHex: string;
-  address: string;
-};
+// window object for OKX Wallet extension
+export const okxProvider = "okxwallet";
 
 export class OKXWallet extends WalletProvider {
-  private okxWalletInfo: OKXWalletInfo | undefined;
+  private okxWalletInfo: WalletInfo | undefined;
 
   constructor() {
     super();
@@ -22,16 +26,16 @@ export class OKXWallet extends WalletProvider {
   connectWallet = async (): Promise<this> => {
     const workingVersion = "2.83.26";
     // check whether there is an OKX Wallet extension
-    if (!window.okxwallet) {
+    if (!window[okxProvider]) {
       throw new Error("OKX Wallet extension not found");
     }
 
-    const version = await window.okxwallet.getVersion();
+    const version = await window[okxProvider].getVersion();
     if (version < workingVersion) {
       throw new Error("Please update OKX Wallet to the latest version");
     }
 
-    const okxwallet = window.okxwallet;
+    const okxwallet = window[okxProvider];
     try {
       await okxwallet.enable(); // Connect to OKX Wallet extension
     } catch (error) {
@@ -93,14 +97,14 @@ export class OKXWallet extends WalletProvider {
       throw new Error("OKX Wallet not connected");
     }
     // sign the PSBTs
-    return await window?.okxwallet?.bitcoinSignet?.signPsbts(psbtsHexes);
+    return await window[okxProvider]?.bitcoinSignet?.signPsbts(psbtsHexes);
   };
 
   signMessageBIP322 = async (message: string): Promise<string> => {
     if (!this.okxWalletInfo) {
       throw new Error("OKX Wallet not connected");
     }
-    return await window?.okxwallet?.bitcoinSignet?.signMessage(
+    return await window[okxProvider].bitcoinSignet?.signMessage(
       message,
       "bip322-simple",
     );
@@ -116,7 +120,7 @@ export class OKXWallet extends WalletProvider {
     }
     // subscribe to account change event
     if (eventName === "accountChanged") {
-      return window.okxwallet.bitcoinSignet.on(eventName, callBack);
+      return window[okxProvider].bitcoinSignet.on(eventName, callBack);
     }
   };
 

--- a/src/utils/wallet/wallet_provider.ts
+++ b/src/utils/wallet/wallet_provider.ts
@@ -26,6 +26,12 @@ export interface UTXO {
 // supported networks
 export type Network = "mainnet" | "testnet" | "regtest" | "signet";
 
+// WalletInfo is a structure defining attributes for a wallet
+export type WalletInfo = {
+  publicKeyHex: string;
+  address: string;
+};
+
 /**
  * Abstract class representing a wallet provider.
  * Provides methods for connecting to a wallet, retrieving wallet information, signing transactions, and more.


### PR DESCRIPTION
- Solves an issue with browsers using `window.btcwallet`
- Wallets should be added to `src/utils/wallet/list.ts`
- Implement an interface similar to `src/utils/wallet/providers/okx_wallet.ts` with `okxProvider`. `okxProvider` defines what window object we are calling. Like `window.okxwallet`
- Wallets extensions that are not installed but integrated will be shown as a button that leads to the docs
- If there's something in `window.btcwallet` (injection mechanism on mobile for example) we show `Browser` button that will use `window.btcwallet`