### PR TITLE
fix text wrap

### DIFF
--- a/src/app/components/Summary/Summary.tsx
+++ b/src/app/components/Summary/Summary.tsx
@@ -23,7 +23,7 @@ export const Summary: React.FC<SummaryProps> = ({
           <p className="dark:text-neutral-content">Total staked</p>
           <div className="flex items-center gap-1">
             <FaBitcoin className="text-primary" size={16} />
-            <p className="font-semibold">
+            <p className="font-semibold whitespace-nowrap">
               {totalStakedSat
                 ? maxDecimals(satoshiToBtc(totalStakedSat), 8)
                 : 0}{" "}
@@ -36,7 +36,7 @@ export const Summary: React.FC<SummaryProps> = ({
           <p className="dark:text-neutral-content">Balance</p>
           <div className="flex items-center gap-1">
             <FaBitcoin className="text-primary" size={16} />
-            <p className="font-semibold">
+            <p className="font-semibold whitespace-nowrap">
               {balanceSat ? maxDecimals(satoshiToBtc(balanceSat), 8) : 0} Signet
               BTC
             </p>


### PR DESCRIPTION
instead of changing decimal number, fixing text wrap would be the better approach for data integrity
<img width="1089" alt="Screenshot 2024-05-24 at 15 28 34" src="https://github.com/babylonchain/simple-staking/assets/168515712/38ee33bf-9599-46e6-b943-2df646367958">
