### PR TITLE
add feedback modal

### DIFF
--- a/src/app/components/Modals/FeedbackModal.tsx
+++ b/src/app/components/Modals/FeedbackModal.tsx
@@ -1,0 +1,126 @@
+import { useRef, useEffect } from "react";
+import { IoMdClose } from "react-icons/io";
+import { Modal } from "react-responsive-modal";
+
+interface FeedbackModalProps {
+  open: boolean;
+  onClose: (value: boolean) => void;
+  type: "success" | "cancel" | null;
+}
+
+const SuccessContent = () => {
+  return (
+    <div className="text-text-black dark:text-white">
+      <div className="mt-6 flex flex-col gap-4">
+        <p>Congratulations on successfully staking your BTC!</p>
+        <p>
+          Note that for your Bitcoin Stake to become Active it needs to be
+          included in a Bitcoin block with sufficient confirmations. This might
+          take up to an hour and you can monitor the confirmations on this page,
+          so stay tuned!
+        </p>
+        <p>
+          Your participation is crucial to our testnet’s success. We invite you
+          to share your experience and feedback in our dedicated thread on the
+          Babylon Forum. Your insights are valuable to us and will help us
+          understand your experience with Bitcoin staking on our Testnet.
+        </p>
+        <p>
+          Visit the{" "}
+          <a
+            href="https://forum.babylonlabs.io/t/feedback-megathread/183"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary"
+          >
+            Testnet Feedback Megathread
+          </a>{" "}
+          to post your thoughts.
+        </p>
+        <p>
+          Thank you for being a part of this groundbreaking journey with us!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const CancelContent = () => {
+  return (
+    <div className="text-text-black dark:text-white">
+      <div className="mt-6 flex flex-col gap-4">
+        <p>
+          We noticed you’re leaving the Bitcoin staking process on our Testnet.
+          Your input is important to us, and we’d appreciate it if you can let
+          us know why.
+        </p>
+        <p>
+          If you need any help with Bitcoin staking, please{" "}
+          <a
+            href="https://forum.babylonlabs.io/c/testnet/41"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary"
+          >
+            Open a New Topic
+          </a>{" "}
+          on our forum and we’d be happy to assist.
+        </p>
+        <p>
+          You can also add your feedback to the{" "}
+          <a
+            href="https://forum.babylonlabs.io/t/feedback-megathread/183"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary"
+          >
+            Testnet Feedback Megathread
+          </a>{" "}
+          to help us make the process better.
+        </p>
+        <p>
+          Thank you for being a part of our Bitcoin Staking Protocol Testnet
+          event!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export const FeedbackModal: React.FC<FeedbackModalProps> = ({
+  open,
+  onClose,
+  type,
+}) => {
+  const modalRef = useRef(null);
+
+  return open ? (
+    <Modal
+      ref={modalRef}
+      open={open}
+      onClose={() => onClose(false)}
+      classNames={{
+        modalContainer: "flex items-end justify-center md:items-center",
+        modal:
+          "m-0 w-full max-w-none rounded-t-2xl bg-base-300 shadow-lg md:w-auto md:max-w-[45rem] md:rounded-b-2xl lg:max-w-[55rem]",
+      }}
+      showCloseIcon={false}
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-bold">
+          {type === "success"
+            ? "Share your Staking Experience!"
+            : "We Value Your Feedback"}
+        </h3>
+        <button
+          className="btn btn-circle btn-ghost btn-sm"
+          onClick={() => onClose(false)}
+        >
+          <IoMdClose size={24} />
+        </button>
+      </div>
+      {type === "success" && <SuccessContent />}
+      {type === "cancel" && <CancelContent />}
+    </Modal>
+  ) : null;
+};

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -82,9 +82,9 @@ export const Staking: React.FC<StakingProps> = ({
     isOpen: boolean;
   }>({ type: null, isOpen: false });
   const [successFeedbackModalOpened, setSuccessFeedbackModalOpened] =
-    useLocalStorage<boolean>("successFeedbackModalOpened", false);
+    useLocalStorage<boolean>("bbn-staking-successFeedbackModalOpened", false);
   const [cancelFeedbackModalOpened, setCancelFeedbackModalOpened] =
-    useLocalStorage<boolean>("cancelFeedbackModalOpened", false);
+    useLocalStorage<boolean>("bbn-staking-cancelFeedbackModalOpened ", false);
 
   const stakingParams = paramWithContext?.currentVersion;
   const isUpgrading = paramWithContext?.isApprochingNextVersion;

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { Transaction, networks } from "bitcoinjs-lib";
+import { useLocalStorage } from "usehooks-ts";
 
 import { FinalityProvider as FinalityProviderInterface } from "@/app/types/finalityProviders";
 import { toLocalStorageDelegation } from "@/utils/local_storage/toLocalStorageDelegation";
@@ -22,6 +23,7 @@ import stakingUpgrading from "./Form/States/staking-upgrading.svg";
 import { useError } from "@/app/context/Error/ErrorContext";
 import { ErrorState } from "@/app/types/errors";
 import { STAKING_FEE_SAT } from "@/app/common/constants";
+import { FeedbackModal } from "../Modals/FeedbackModal";
 
 interface OverflowProperties {
   isOverTheCap: boolean;
@@ -75,6 +77,14 @@ export const Staking: React.FC<StakingProps> = ({
     useState<FinalityProviderInterface>();
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
   const [resetFormInputs, setResetFormInputs] = useState(false);
+  const [feedbackModal, setFeedbackModal] = useState<{
+    type: "success" | "cancel" | null;
+    isOpen: boolean;
+  }>({ type: null, isOpen: false });
+  const [successFeedbackModalOpened, setSuccessFeedbackModalOpened] =
+    useLocalStorage<boolean>("successFeedbackModalOpened", false);
+  const [cancelFeedbackModalOpened, setCancelFeedbackModalOpened] =
+    useLocalStorage<boolean>("cancelFeedbackModalOpened", false);
 
   const stakingParams = paramWithContext?.currentVersion;
   const isUpgrading = paramWithContext?.isApprochingNextVersion;
@@ -123,6 +133,13 @@ export const Staking: React.FC<StakingProps> = ({
           STAKING_FEE_SAT,
           publicKeyNoCoord,
         );
+        if (
+          !feedbackModal.isOpen &&
+          feedbackModal.type !== "success" &&
+          !successFeedbackModalOpened
+        ) {
+          setFeedbackModal({ type: "success", isOpen: true });
+        }
       } catch (error: Error | any) {
         throw error;
       }
@@ -180,6 +197,26 @@ export const Staking: React.FC<StakingProps> = ({
 
   const handleStakingTimeBlocksChange = (inputTimeBlocks: number) => {
     setStakingTimeBlocks(inputTimeBlocks);
+  };
+
+  const handlePreviewModalClose = (isOpen: boolean) => {
+    setPreviewModalOpen(isOpen);
+    if (
+      !feedbackModal.isOpen &&
+      feedbackModal.type !== "cancel" &&
+      !cancelFeedbackModalOpened
+    ) {
+      setFeedbackModal({ type: "cancel", isOpen: true });
+    }
+  };
+
+  const handleCloseFeedbackModal = () => {
+    if (feedbackModal.type === "success") {
+      setSuccessFeedbackModalOpened(true);
+    } else if (feedbackModal.type === "cancel") {
+      setCancelFeedbackModalOpened(true);
+    }
+    setFeedbackModal({ type: null, isOpen: false });
   };
 
   const renderStakingForm = () => {
@@ -292,7 +329,7 @@ export const Staking: React.FC<StakingProps> = ({
             </button>
             <PreviewModal
               open={previewModalOpen}
-              onClose={setPreviewModalOpen}
+              onClose={handlePreviewModalClose}
               onSign={handleSign}
               finalityProvider={finalityProvider?.description.moniker}
               stakingAmountSat={stakingAmountSat}
@@ -325,6 +362,13 @@ export const Staking: React.FC<StakingProps> = ({
           {renderStakingForm()}
         </div>
       </div>
+      {feedbackModal.isOpen && (
+        <FeedbackModal
+          open={feedbackModal.isOpen}
+          onClose={handleCloseFeedbackModal}
+          type={feedbackModal.type}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
contains local storage flags to make sure the feedback modals only open once.

Close #56 

<img width="452" alt="Screenshot 2024-05-26 at 14 56 00" src="https://github.com/babylonchain/simple-staking/assets/168515712/a13bf4cf-0d36-4c63-8ffd-4925d2ac4c5d">

<img width="1445" alt="Screenshot 2024-05-26 at 14 55 55" src="https://github.com/babylonchain/simple-staking/assets/168515712/0112f242-8ae1-47f9-9baf-51cf4d00646f">
<img width="1450" alt="Screenshot 2024-05-26 at 14 56 14" src="https://github.com/babylonchain/simple-staking/assets/168515712/60222bf5-87e6-4dd3-92ce-a5f44e253988">
<img width="452" alt="Screenshot 2024-05-26 at 14 56 22" src="https://github.com/babylonchain/simple-staking/assets/168515712/03cf4fcb-bb08-4622-86b0-d63a17f4202a">
