### PR TITLE
feature: Finality providers mobile fit

### DIFF
--- a/src/app/components/Staking/FinalityProviders/FinalityProvider.tsx
+++ b/src/app/components/Staking/FinalityProviders/FinalityProvider.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image";
+import { Tooltip } from "react-tooltip";
 
 import { Hash } from "@/app/components/Hash/Hash";
 import blue from "@/app/assets/blue-check.svg";
 import { satoshiToBtc } from "@/utils/btcConversions";
 import { maxDecimals } from "@/utils/maxDecimals";
+import { AiOutlineInfoCircle } from "react-icons/ai";
 
 interface FinalityProviderProps {
   moniker: string;
@@ -44,13 +46,31 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
         <div className="flex justify-end lg:justify-start">
           <Hash value={pkHex} address small noFade />
         </div>
-        <div className="flex gap-1">
+        <div className="flex items-center gap-1">
           <p className="hidden sm:flex lg:hidden">Delegation:</p>
           <p>{maxDecimals(satoshiToBtc(stakeSat), 8)} Signet BTC</p>
+          <span
+            className="inline-flex cursor-pointer text-xs sm:hidden"
+            data-tooltip-id={`tooltip-delegation-${pkHex}`}
+            data-tooltip-content="Total delegation"
+            data-tooltip-place="right"
+          >
+            <AiOutlineInfoCircle />
+          </span>
+          <Tooltip id={`tooltip-delegation-${pkHex}`} />
         </div>
-        <div className="flex justify-end gap-1 lg:justify-start">
+        <div className="flex items-center justify-end gap-1 lg:justify-start">
           <p className="hidden sm:flex lg:hidden">Comission:</p>
           {maxDecimals(Number(comission) * 100, 2)}%
+          <span
+            className="inline-flex cursor-pointer text-xs sm:hidden"
+            data-tooltip-id={`tooltip-delegation-${pkHex}`}
+            data-tooltip-content="Total delegation"
+            data-tooltip-place="top"
+          >
+            <AiOutlineInfoCircle />
+          </span>
+          <Tooltip id={`tooltip-delegation-${pkHex}`} />
         </div>
       </div>
     </div>

--- a/src/app/components/Staking/FinalityProviders/FinalityProvider.tsx
+++ b/src/app/components/Staking/FinalityProviders/FinalityProvider.tsx
@@ -30,7 +30,7 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
       className={`${generalStyles} ${selected ? "fp-selected" : ""}`}
       onClick={onClick}
     >
-      <div className="grid grid-cols-2 grid-rows-2 items-center gap-2 lg:grid-cols-stakingFinalityProviders lg:grid-rows-1">
+      <div className="grid-cols-stakingFinalityProvidersMobile lg:grid-cols-stakingFinalityProvidersDesktop grid grid-rows-2 items-center gap-2 lg:grid-rows-1">
         <div>
           {moniker ? (
             <div className="flex items-center gap-1">
@@ -41,13 +41,15 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
             "-"
           )}
         </div>
-        <Hash value={pkHex} address small noFade />
-        <div className="flex gap-1">
-          <p className="lg:hidden">Total Delegation:</p>
-          <p>{maxDecimals(satoshiToBtc(stakeSat), 8)} Signet BTC</p>
+        <div className="flex justify-end lg:justify-start">
+          <Hash value={pkHex} address small noFade />
         </div>
         <div className="flex gap-1">
-          <p className="lg:hidden">Comission:</p>
+          <p className="hidden sm:flex lg:hidden">Delegation:</p>
+          <p>{maxDecimals(satoshiToBtc(stakeSat), 8)} Signet BTC</p>
+        </div>
+        <div className="flex justify-end gap-1 lg:justify-start">
+          <p className="hidden sm:flex lg:hidden">Comission:</p>
           {maxDecimals(Number(comission) * 100, 2)}%
         </div>
       </div>

--- a/src/app/components/Staking/FinalityProviders/FinalityProviders.tsx
+++ b/src/app/components/Staking/FinalityProviders/FinalityProviders.tsx
@@ -42,7 +42,7 @@ export const FinalityProviders: React.FC<FinalityProvidersProps> = ({
         </a>
         .
       </p>
-      <div className="hidden gap-2 px-4 lg:grid lg:grid-cols-stakingFinalityProviders">
+      <div className="lg:grid-cols-stakingFinalityProvidersDesktop hidden gap-2 px-4 lg:grid">
         <p>Finality Provider</p>
         <p>BTC PK</p>
         <p>Total Delegation</p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,8 +22,8 @@ const config: Config = {
         "base-400": "hsl(var(--base-400) / <alpha-value>)",
       },
       gridTemplateColumns: {
-        finalityProviders: "2fr 1fr 1.75fr",
-        stakingFinalityProviders: "2fr 1.5fr 2fr 0.75fr",
+        stakingFinalityProvidersMobile: "2fr 1fr",
+        stakingFinalityProvidersDesktop: "2fr 1.5fr 2fr 0.75fr",
       },
     },
   },


### PR DESCRIPTION
When on small mobile:
- No "Delegation" and "Comission" labels: https://i.imgur.com/wX5gHIw.png
- FP Moniker and Staking amount is 2x wider than Hash and Comission: https://i.imgur.com/tOFAYDw.png

When on bigger mobile:
- "Delegation" and "Comission" fields appear: https://i.imgur.com/BOJX7iS.png

Desktop
- "Table" as usual: https://i.imgur.com/YPbtE2q.png