### PR TITLE
chore: show the pending confirmation depth from global param

### DIFF
--- a/src/app/components/Delegations/Delegation.tsx
+++ b/src/app/components/Delegations/Delegation.tsx
@@ -9,6 +9,7 @@ import { trim } from "@/utils/trim";
 import { satoshiToBtc } from "@/utils/btcConversions";
 import { maxDecimals } from "@/utils/maxDecimals";
 import { useEffect, useState } from "react";
+import { GlobalParamsVersion } from "@/app/types/globalParams";
 
 interface DelegationProps {
   finalityProviderMoniker: string;
@@ -23,6 +24,7 @@ interface DelegationProps {
   // has not had time to reflect this change yet
   intermediateState?: string;
   isOverflow: boolean;
+  globalParamsVersion: GlobalParamsVersion
 }
 
 export const Delegation: React.FC<DelegationProps> = ({
@@ -34,6 +36,7 @@ export const Delegation: React.FC<DelegationProps> = ({
   onWithdraw,
   intermediateState,
   isOverflow,
+  globalParamsVersion,
 }) => {
   const { startTimestamp } = stakingTx;
   const [currentTime, setCurrentTime] = useState(Date.now());
@@ -98,11 +101,12 @@ export const Delegation: React.FC<DelegationProps> = ({
   };
 
   const renderStateTooltip = () => {
+    const confirmationDepth = globalParamsVersion?.confirmationDepth;
     // overflow should be shown only on active state
     if (isOverflow && isActive) {
-      return getStateTooltip(DelegationState.OVERFLOW);
+      return getStateTooltip(DelegationState.OVERFLOW, confirmationDepth);
     } else {
-      return getStateTooltip(intermediateState || state);
+      return getStateTooltip(intermediateState || state, confirmationDepth);
     }
   };
 

--- a/src/app/components/Delegations/Delegations.tsx
+++ b/src/app/components/Delegations/Delegations.tsx
@@ -365,7 +365,7 @@ export const Delegations: React.FC<DelegationsProps> = ({
   const combinedDelegationsData = delegationsAPI
     ? [...delegationsLocalStorage, ...delegationsAPI]
     : // if no API data, fallback to using only local storage delegations
-      delegationsLocalStorage;
+    delegationsLocalStorage;
 
   return (
     <div className="card flex flex-col gap-2 bg-base-300 p-4 shadow-sm lg:flex-1">
@@ -427,6 +427,7 @@ export const Delegations: React.FC<DelegationsProps> = ({
                     }
                     intermediateState={intermediateDelegation?.state}
                     isOverflow={isOverflow}
+                    globalParamsVersion={globalParamsVersion}
                   />
                 );
               })}

--- a/src/utils/getState.ts
+++ b/src/utils/getState.ts
@@ -30,7 +30,7 @@ export const getState = (state: string) => {
 };
 
 // Create state tooltips for the additional information
-export const getStateTooltip = (state: string) => {
+export const getStateTooltip = (state: string, confirmationDepth?: number) => {
   switch (state) {
     case DelegationState.ACTIVE:
       return "Stake is active";
@@ -43,7 +43,7 @@ export const getStateTooltip = (state: string) => {
     case DelegationState.WITHDRAWN:
       return "Stake has been withdrawn";
     case DelegationState.PENDING:
-      return "Stake is pending 6 Bitcoin confirmations";
+      return `Stake is pending ${confirmationDepth || 10} Bitcoin confirmations`;
     case DelegationState.OVERFLOW:
       return "Stake is over the staking cap";
     case DelegationState.EXPIRED:


### PR DESCRIPTION
<img width="288" alt="image" src="https://github.com/babylonchain/simple-staking/assets/154598612/37216bf4-33f4-4def-9e09-bc8806f3e454">
