### PR TITLE
add staking start height to localStorageDelegation

### DIFF
--- a/src/app/components/Delegations/Delegations.tsx
+++ b/src/app/components/Delegations/Delegations.tsx
@@ -162,6 +162,7 @@ export const Delegations: React.FC<DelegationsProps> = ({
         delegation.stakingTx.txHex,
         delegation.stakingTx.timelock,
         DelegationState.INTERMEDIATE_UNBONDING,
+        delegation.stakingTx.startHeight,
       ),
       ...delegations,
     ]);
@@ -284,6 +285,7 @@ export const Delegations: React.FC<DelegationsProps> = ({
         delegation.stakingTx.txHex,
         delegation.stakingTx.timelock,
         DelegationState.INTERMEDIATE_WITHDRAWAL,
+        delegation.stakingTx.startHeight
       ),
       ...delegations,
     ]);

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -88,7 +88,7 @@ export const Staking: React.FC<StakingProps> = ({
 
   const stakingParams = paramWithContext?.currentVersion;
   const firstActivationHeight = paramWithContext?.firstActivationHeight;
-  const height = paramWithContext?.height;
+  const height = paramWithContext ? paramWithContext.height : 0;
   const isUpgrading = paramWithContext?.isApprochingNextVersion;
   const isBlockHeightUnderActivation =
     !stakingParams ||
@@ -160,7 +160,7 @@ export const Staking: React.FC<StakingProps> = ({
           stakingAmountSat,
           signedTxHex,
           stakingTerm,
-          height ? height : 0,
+          height,
         ),
         ...delegations,
       ]);

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -45,8 +45,8 @@ interface StakingProps {
   setDelegationsLocalStorage: Dispatch<SetStateAction<Delegation[]>>;
   paramWithContext:
     | {
-        height: number | undefined;
-        firstActivationHeight: number | undefined;
+        height: number;
+        firstActivationHeight: number;
         currentVersion: GlobalParamsVersion | undefined;
         isApprochingNextVersion: boolean | undefined;
       }
@@ -160,6 +160,7 @@ export const Staking: React.FC<StakingProps> = ({
           stakingAmountSat,
           signedTxHex,
           stakingTerm,
+          height ? height : 0,
         ),
         ...delegations,
       ]);

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -88,7 +88,7 @@ export const Staking: React.FC<StakingProps> = ({
 
   const stakingParams = paramWithContext?.currentVersion;
   const firstActivationHeight = paramWithContext?.firstActivationHeight;
-  const height = paramWithContext ? paramWithContext.height : 0;
+  const height = paramWithContext?.height || 0;
   const isUpgrading = paramWithContext?.isApprochingNextVersion;
   const isBlockHeightUnderActivation =
     !stakingParams ||

--- a/src/utils/local_storage/toLocalStorageDelegation.ts
+++ b/src/utils/local_storage/toLocalStorageDelegation.ts
@@ -7,6 +7,7 @@ export const toLocalStorageDelegation = (
   stakingValueSat: number,
   stakingTxHex: string,
   timelock: number,
+  startHeight: number,
 ): Delegation => ({
   stakingTxHashHex: stakingTxHashHex,
   stakerPkHex: stakerPkHex,
@@ -17,7 +18,7 @@ export const toLocalStorageDelegation = (
     txHex: stakingTxHex,
     outputIndex: 0,
     startTimestamp: new Date().toISOString(),
-    startHeight: 0,
+    startHeight,
     timelock,
   },
   isOverflow: false,

--- a/src/utils/local_storage/toLocalStorageIntermediateDelegation.ts
+++ b/src/utils/local_storage/toLocalStorageIntermediateDelegation.ts
@@ -8,6 +8,7 @@ export const toLocalStorageIntermediateDelegation = (
   stakingTxHex: string,
   timelock: number,
   state: string,
+  startHeight: number,
 ): Delegation => ({
   stakingTxHashHex,
   stakerPkHex,
@@ -18,7 +19,7 @@ export const toLocalStorageIntermediateDelegation = (
     txHex: stakingTxHex,
     outputIndex: 0,
     startTimestamp: new Date().toISOString(),
-    startHeight: 0,
+    startHeight,
     timelock,
   },
   isOverflow: false,


### PR DESCRIPTION
<img width="776" alt="Screenshot 2024-05-28 at 03 55 05" src="https://github.com/babylonchain/simple-staking/assets/168515712/98426dfc-9d5c-4fa0-8901-6968601d04fc">

save the staking start height when start new staking to ensure the globalParams infos are retrieved correctly