### PR TITLE
feature: Initial ordinals threshold

### DIFF
--- a/src/utils/mempool_api.ts
+++ b/src/utils/mempool_api.ts
@@ -5,6 +5,9 @@ import { Fees, UTXO } from "./wallet/wallet_provider";
 
 const { mempoolApiUrl } = getNetworkConfig();
 
+// Amount of satoshis below which we consider a UTXO to be an ordinal
+const ORDINALS_THRESHOLD = 1500;
+
 /*
     URL Construction methods
 */
@@ -163,7 +166,6 @@ export async function getFundingUTXOs(
   }
 
   // We need to cut BRC-20, ARC-20, Runes, and other tokens from the list of UTXOs
-  const ORDINALS_THRESHOLD = 1500;
   let confirmedUTXOsWithoutOrdinals = [...confirmedUTXOs];
   if (isTaproot(addressInfo.address)) {
     confirmedUTXOsWithoutOrdinals = confirmedUTXOsWithoutOrdinals.filter(


### PR DESCRIPTION
Cuts down the UTXOs with value below the threshold
From my tests, it's:

- DUST
- 600 sat
- 1200 sat

Put 1500 to be on the safer side

@vitsalis @jrwbabylonchain what do you think about the balance? More of a UI/UX thing — should we rewrite the balance to use the sum of "proper" filtered UTXOs without any ordinals? 