### PR TITLE
Change the way we build docker images

### DIFF
--- a/.env.production.config
+++ b/.env.production.config
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_MEMPOOL_API=https://babylon.mempool.space
+NEXT_PUBLIC_API_URL=https://staking-api.btc-mainnet.babylonchain.io
+NEXT_PUBLIC_NETWORK=mainnet
+NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES=false

--- a/.github/workflows/sync_pr_dev_to_main.yml
+++ b/.github/workflows/sync_pr_dev_to_main.yml
@@ -2,13 +2,13 @@ name: Create Sync PR from Main to Dev
 
 on:
   schedule:
-  - cron: "0 0 * * *" 
+    - cron: "0 0 * * *"
 
 jobs:
   call_sync_branch:
     uses: babylonchain/.github/.github/workflows/reusable_sync_branch.yml@v0.2.0
     with:
-      base_branch: 'main'
-      target_branch: 'dev'
-      reviewers: 'jrwbabylonchain,gbarkhatov,jeremy-babylonchain'
+      base_branch: "main"
+      target_branch: "dev"
+      reviewers: "jrwbabylonchain,gbarkhatov,jeremy-babylonchain"
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:22-alpine3.19 AS builder
 
 WORKDIR /app
 
+ARG CONFIG_FILE
+
 COPY package.json package-lock.json ./
 # Install dependencies with npm
 RUN npm ci
@@ -14,16 +16,11 @@ COPY tsconfig.json .
 COPY tailwind.config.ts .
 COPY postcss.config.js .
 COPY docker-entrypoint.sh .
+# We copy in the config file we specified and we expect this COPY
+# to fail if the file doesn't exists.
+COPY $CONFIG_FILE .env
 
-# We replace NEXT_PUBLIC_* variables here with placeholders
-# as next.js automatically replaces those during building
-# Later the docker-entrypoint.sh script finds such variables and replaces them
-# with the docker environment variables we have set
-RUN NEXT_PUBLIC_MEMPOOL_API=APP_NEXT_PUBLIC_MEMPOOL_API \
-    NEXT_PUBLIC_API_URL=APP_NEXT_PUBLIC_API_URL \
-    NEXT_PUBLIC_NETWORK=APP_NEXT_PUBLIC_NETWORK \
-    NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES=APP_NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES \
-    npm run build
+RUN npm run build
 
 # Step 2. Production image, copy all the files and run next
 FROM node:22-alpine3.19 AS runner

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Then, to start a development server:
 npm run dev
 ```
 
+## Production build
+
+```bash
+docker build \
+  --build-arg CONFIG_FILE=.env.production.config \
+  -t babylonchain/simple-staking .
+```
+
 ## Wallet Integration
 
 Instructions for wallet integration can be found in this

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env sh
 set -Ex
 
-# This method has been inspired by the comment here:
-# https://github.com/vercel/next.js/discussions/17641#discussioncomment-339555
-function apply_path {
-    find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_MEMPOOL_API#$MEMPOOL_API#g"
-    find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_API_URL#$API_URL#g"
-    find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_NETWORK#$NETWORK#g"
-    find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES#$DISPLAY_TESTING_MESSAGES#g"
-}
-
-apply_path
 echo "Starting Nextjs"
 exec "$@"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "clean": "rm -r node_modules",
-    "build-docker": "docker build -t babylonchain/simple-staking .",
+    "build-docker": "docker build --build-arg CONFIG_FILE=.env.production.config -t babylonchain/simple-staking .",
     "clean-docker": "docker rmi babylonchain/simple-staking 2>/dev/null; true",
     "prepare": "husky",
     "sort-imports": "eslint --fix .",


### PR DESCRIPTION
The way we deal with environment variables in the `docker-entrypoint.sh` can be error prone. The problem caused #354 was that the page was pre-generated during build time so the environment variable replacing doesn't work for it. As a result, it causes hydration mismatch. IMO, I think we should stick to build time environment variables so that we can generate the correct bundle for each environment.
In this PR, I created a new `.env.production.config` contains production configs that can be copied into `docker build` process. If we need a different environment, just create new config files for different environments. In this way, the config change for each environment can be git committed and traced.

There is this [confluence page](https://babylonlabs.atlassian.net/wiki/spaces/~5dedc22cbf265f0e3bbc8ae2/pages/10911788/simple-staking+bundling) that explains it in more details. Let me know what do you think.